### PR TITLE
Dry run

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,29 +18,33 @@ To install the binary, you could:
 ```
 $ n2o
 Usage of n2o:
- -download-images
- download external images to the Obsidian vault
- -notion-db-ID string
- Notion database to migrate
- -notion-page-ID string
- Notion page to migrate
- -notion-token string
- Notion token
- -page-name string
- Notion page properties to extract the Obsidian page title.
- Support selecting different page attributes and formatting. To select multiple properties, use a comma-separated list.
- The attributes that support custom formatting are Notion date attributes.
- Example of how to use a Notion date property with custom format as the title for the Obsidian page:
- -name=date:%Y/%B/%d-%A
- (default "Name")
- -page-properties string
- Notion page properties to convert to Obsidian frontmater.
- You can select multiple properties using a comma-separated list.
+  -download-images
+    	download external images to the Obsidian vault
+  -dry-run
+    	do not write the pages in the Obsidian vault. Output to stdout what pages would be created in the Obsidian vault
+  -notion-db-ID string
+    	Notion database to migrate
+  -notion-page-ID string
+    	Notion page to migrate
+  -notion-token string
+    	Notion token
+  -page-name string
+    	Notion page properties to extract the Obsidian page title.
+    	Support selecting different page attributes and formatting. To select multiple properties, use a comma-separated list.
+    	The attributes that support custom formatting are Notion date attributes.
+    	Example of how to use a Notion date property with custom format as the title for the Obsidian page:
+    	-name=date:%Y/%B/%d-%A
 
- -vault-folder string
- folder to store pages inside the Obsidian Vault
- -vault-path string
- Obsidian vault location
+    	By default if you do not configure any we get the Title property
+
+  -page-properties string
+    	Notion page properties to convert to Obsidian frontmater.
+    	You can select multiple properties using a comma-separated list.
+
+  -vault-folder string
+    	folder to store pages inside the Obsidian Vault
+  -vault-path string
+    	Obsidian vault location
 ```
 
 ## How do you get your Notion token?

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -35,7 +35,7 @@ var filenameFromPage = flag.String("page-name", "", filenameFromPageExplanation)
 var obsidianVault = flag.String("vault-path", os.Getenv("N2O_OBSIDIAN_VAULT_PATH"), "Obsidian vault location")
 var vaultDestination = flag.String("vault-folder", "", "folder to store pages inside the Obsidian Vault")
 var storeImages = flag.Bool("download-images", false, "download external images to the Obsidian vault")
-var dryRun = flag.Bool("dry-run", false, "do not write the pages in the Obsidian vault. Output to stdout what pages would be created and their links")
+var dryRun = flag.Bool("dry-run", false, "do not write the pages in the Obsidian vault. Output to stdout what pages would be created in the Obsidian vault")
 
 func main() {
 	flag.Parse()

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -33,6 +33,7 @@ var filenameFromPage = flag.String("page-name", "Name", filenameFromPageExplanat
 var obsidianVault = flag.String("vault-path", os.Getenv("N2O_OBSIDIAN_VAULT_PATH"), "Obsidian vault location")
 var vaultDestination = flag.String("vault-folder", "", "folder to store pages inside the Obsidian Vault")
 var storeImages = flag.Bool("download-images", false, "download external images to the Obsidian vault")
+var dryRun = flag.Bool("dry-run", false, "do not write the pages in the Obsidian vault. Output to stdout what pages would be created and their links")
 
 func main() {
 	flag.Parse()
@@ -98,6 +99,7 @@ func main() {
 		PagePropertiesToMigrate: pageProperties,
 		VaultPath:               *obsidianVault,
 		VaultDestination:        *vaultDestination,
+		DryRun:                  *dryRun,
 	}
 
 	ctx := context.Background()
@@ -130,7 +132,11 @@ func main() {
 		job := &queue.Job{
 			Path: path,
 			Run: func() error {
-				return migrator.FetchParseAndSavePage(ctx, page, config.PagePropertiesToMigrate, path)
+				if config.DryRun {
+					return migrator.FetchAndDisplayInformation(ctx, page, path)
+				} else {
+					return migrator.FetchParseAndSavePage(ctx, page, config.PagePropertiesToMigrate, path)
+				}
 			},
 		}
 

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,24 +1,31 @@
 package cache
 
-import "sync"
+import (
+	"sync"
+)
+
+type Page struct {
+	Title   string
+	Content string
+}
 
 type Cache struct {
-	storage map[string]string
+	storage map[string]Page
 	working map[string]bool
 	mu      sync.RWMutex
 }
 
-func (c *Cache) Get(value string) (string, bool) {
+func (c *Cache) Get(value string) (Page, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	val, ok := c.storage[value]
 	return val, ok
 }
 
-func (c *Cache) Set(key, value string) {
+func (c *Cache) Set(key string, page Page) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.storage[key] = value
+	c.storage[key] = page
 	c.working[key] = false
 }
 
@@ -35,7 +42,7 @@ func (c *Cache) IsWorking(key string) bool {
 }
 
 func NewCache() *Cache {
-	storage := map[string]string{}
+	storage := map[string]Page{}
 	working := map[string]bool{}
 	return &Cache{
 		storage: storage,

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -5,8 +5,7 @@ import (
 )
 
 type Page struct {
-	Title   string
-	Content string
+	Title string
 }
 
 type Cache struct {

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -22,9 +22,11 @@ func TestCache(t *testing.T) {
 	working = c.IsWorking(key)
 	assert.True(t, working)
 
-	c.Set(key, "foo")
+	c.Set(key, Page{
+		Title: "foo",
+	})
 
 	val, ok := c.Get(key)
 	assert.True(t, ok)
-	assert.Equal(t, "foo", val)
+	assert.Equal(t, "foo", val.Title)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	VaultDestination        string
 	StoreImages             bool
 	PageNameFilters         map[string]string
+	DryRun                  bool
 }
 
 func (c Config) VaultFilepath() string {

--- a/internal/migrator/fixtures/expected_nested_page
+++ b/internal/migrator/fixtures/expected_nested_page
@@ -1,6 +1,6 @@
 https://github.com/Shopify/cli-ui
 
-The cli-ui gem provides utility functions to create dynamic, beautiful CLI prompts quickly. Is used extensible [[Personal Notes/ANSI Codes for the terminal]] codes to format the text, as well as other advanced techniques
+The cli-ui gem provides utility functions to create dynamic, beautiful CLI prompts quickly. Is used extensible [[Personal Notes/ANSI Codes for the terminal.md]] codes to format the text, as well as other advanced techniques
 The gem is thread-safe and uses extensible the `Thread.current` API to store thread local information. The gem has some very interesting code snippets. 
 
 ### Capturing terminal information

--- a/internal/migrator/migrator.go
+++ b/internal/migrator/migrator.go
@@ -169,6 +169,27 @@ func (m Migrator) FetchParseAndSavePage(ctx context.Context, page notion.Page, p
 	return nil
 }
 
+func (m Migrator) FetchAndDisplayInformation(ctx context.Context, page notion.Page, storePath string) error {
+	pageBlocks, err := m.Client.FindBlockChildrenByID(ctx, page.ID, nil)
+	if err != nil {
+		return fmt.Errorf("failed to extract children blocks for block ID %s. error: %w", page.ID, err)
+	}
+
+	buffer := bufio.NewWriter(&strings.Builder{})
+
+	// err = m.pageToMarkdown(ctx, pageBlocks.Results, buffer, false)
+
+	// if err != nil {
+	// 	return fmt.Errorf("failed to convert page to markdown. error: %w", err)
+	// }
+
+	// if err = buffer.Flush(); err != nil {
+	// 	return fmt.Errorf("failed to write into the markdown file %s. error: %w", path.Base(m.Config.VaultPath), err)
+	// }
+
+	return nil
+}
+
 func (m Migrator) propertiesToFrontMatter(ctx context.Context, sortedKeys []string, propertites notion.DatabasePageProperties, buffer *bufio.Writer) {
 	buffer.WriteString("---\n")
 	// There is a limitation between Notions and Obsidian.
@@ -628,7 +649,6 @@ func (m Migrator) pageToMarkdown(ctx context.Context, blocks []notion.Block, buf
 				}
 				buffer.WriteString("\n")
 			}
-
 		case *notion.VideoBlock:
 			if block.Type == notion.FileTypeExternal {
 				if indent {

--- a/internal/migrator/migrator.go
+++ b/internal/migrator/migrator.go
@@ -486,11 +486,14 @@ func (m *Migrator) fetchPage(ctx context.Context, parentPage *page, pageID, titl
 		m.Cache.Mark(pageID)
 		var result string
 
-		emptyList := map[string]bool{}
 		extractTitle := false
 		childTitle := title
 		if childTitle == "" {
 			extractTitle = true
+		} else {
+			if !strings.HasSuffix(childTitle, ".md") {
+				childTitle = fmt.Sprintf("%s.md", childTitle)
+			}
 		}
 
 		defer func() {
@@ -534,7 +537,7 @@ func (m *Migrator) fetchPage(ctx context.Context, parentPage *page, pageID, titl
 
 			parentPage.children = append(parentPage.children, newPage)
 
-			if err = m.fetchParseAndSavePage(ctx, newPage, emptyList); err != nil {
+			if err = m.fetchParseAndSavePage(ctx, newPage, m.Config.PagePropertiesToMigrate); err != nil {
 				return fmt.Errorf("failed to fetch and save mention page %s content with DB %s. error: %w", childTitle, mentionPage.Parent.DatabaseID, err)
 			}
 		case notion.ParentTypeBlock:
@@ -556,7 +559,7 @@ func (m *Migrator) fetchPage(ctx context.Context, parentPage *page, pageID, titl
 
 			parentPage.children = append(parentPage.children, newPage)
 
-			if err = m.fetchParseAndSavePage(ctx, newPage, emptyList); err != nil {
+			if err = m.fetchParseAndSavePage(ctx, newPage, m.Config.PagePropertiesToMigrate); err != nil {
 				return fmt.Errorf("failed to fetch and save mention page %s content with block parent %s. error: %w", childTitle, mentionPage.Parent.BlockID, err)
 			}
 		case notion.ParentTypePage:
@@ -579,7 +582,7 @@ func (m *Migrator) fetchPage(ctx context.Context, parentPage *page, pageID, titl
 
 			parentPage.children = append(parentPage.children, newPage)
 
-			if err = m.fetchParseAndSavePage(ctx, newPage, emptyList); err != nil {
+			if err = m.fetchParseAndSavePage(ctx, newPage, m.Config.PagePropertiesToMigrate); err != nil {
 				fmt.Printf("failed to fetch mention page content with page parent: %s\n", childTitle)
 			}
 		default:

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -121,7 +121,6 @@ func (w *Worker) DoWork() bool {
 	for {
 		select {
 		case <-w.Queue.ctx.Done():
-			fmt.Print("Finish migrating pages\n")
 			return true
 		case job := <-w.Queue.jobs:
 			err := job.Run()


### PR DESCRIPTION
- Add `dry-run` option. It allow to fetch the information from notion and display a useful message detailing the different pages that would be created in your Obsidian vault
- Fixed a few issues with page titles: We now append the DB name in the path, we support extracting page title from all type of pages 
- Update tests and README